### PR TITLE
Fix typo in strings.xml

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -94,7 +94,7 @@
 	<string name="msg_list_copied_to_clipboard">%1$d/%2$d items copied to clipboard</string>
 	<string name="msg_name_does_not_support_variables">Name does not support variables</string>
 	<string name="msg_this_cannot_be_undone">This cannot be undone</string>
-	<string name="lbl_annotations_description">Annotations can be referenced in templates as ${comment} and may themselves contain other variables (${packagename}, ${displayname}, ${source}, ${uid}, ${version}, ${versioncode}, ${firstinstalled}, ${lastupdated}, ${datadir}, $targetsdk}, ${tags} and ${marketid}). Annotations are kept when their app is deinstalled in case it gets reinstalled later. Tags allow for grouping apps for faster selection.</string>
+	<string name="lbl_annotations_description">Annotations can be referenced in templates as ${comment} and may themselves contain other variables (${packagename}, ${displayname}, ${source}, ${uid}, ${version}, ${versioncode}, ${firstinstalled}, ${lastupdated}, ${datadir}, ${targetsdk}, ${tags} and ${marketid}). Annotations are kept when their app is deinstalled in case it gets reinstalled later. Tags allow for grouping apps for faster selection.</string>
 	<string name="btn_save">Save</string>
 	<string name="btn_cancel">Cancel</string>
 	<string name="hint_my_tags">Tags (comma separated)</string>


### PR DESCRIPTION
Report my PR https://github.com/onyxbits/listmyaps/pull/18 according to comments on https://github.com/onyxbits/listmyaps/issues/17

Change "$targetsdk}" to "${targetsdk}"
